### PR TITLE
Update module references to reflect new ownership

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,5 +39,5 @@ changelog:
     - '^test:'
 release:
   github:
-    owner: fullstorydev
+    owner: immersa-co
     name: relay-core

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export PROJECT_HOME := $(shell pwd)
 export DIST_PATH     := $(PROJECT_HOME)/dist
-export RELAY_MODULE := github.com/fullstorydev/relay-core
+export RELAY_MODULE := github.com/immersa-co/relay-core
 
 .PHONY: all compile test clean
 

--- a/catcher/main/main.go
+++ b/catcher/main/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/fullstorydev/relay-core/catcher"
+	"github.com/immersa-co/relay-core/catcher"
 )
 
 var logger = log.New(os.Stdout, "[catcher] ", 0)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,8 +8,8 @@ to do anything special to load them.
 ## Writing plugins
 
 To write a plugin for Relay, you need to write implementations for the
-[PluginFactory and Plugin interfaces](https://github.com/fullstorydev/relay-core/blob/master/relay/traffic/plugin-interfaces.go).
-The [built-in plugins](https://github.com/fullstorydev/relay-core/tree/master/relay/plugins/traffic)
+[PluginFactory and Plugin interfaces](https://github.com/immersa-co/relay-core/blob/master/relay/traffic/plugin-interfaces.go).
+The [built-in plugins](https://github.com/immersa-co/relay-core/tree/master/relay/plugins/traffic)
 may serve as a useful starting point.
 
 Plugins are built and tested as part of the Relay code, so you can simply run
@@ -17,7 +17,7 @@ Plugins are built and tested as part of the Relay code, so you can simply run
 
 To use your new plugin, you'll need to add it to the either the `DefaultPlugins`
 or `TestPlugins`
-[registry](https://github.com/fullstorydev/relay-core/blob/master/relay/traffic/plugin-loader/registry.go).
+[registry](https://github.com/immersa-co/relay-core/blob/master/relay/traffic/plugin-loader/registry.go).
 Plugins in the `DefaultPlugins` registry are loaded by `relay` program at
 startup. Plugins in the `TestPlugins` registry are not loaded by the `relay`
 program, but are available in unit tests.

--- a/docs/running.md
+++ b/docs/running.md
@@ -3,7 +3,7 @@
 The Relay service is available as a Docker image. Unless you need a custom
 build, using a Docker image is the easiest way to get up and running quickly.
 
-- [Pre-built Docker images](https://github.com/fullstorydev/relay-core/packages)
+- [Pre-built Docker images](https://github.com/immersa-co/relay-core/packages)
 
 ## Getting Docker images
 
@@ -20,7 +20,7 @@ you'll need to authenticate the Docker CLI using
 
 Once Docker is authenticated with GitHub you can pull the image using `docker pull`.
 You can find the necessary command on the
-[relay-core package page](https://github.com/fullstorydev/relay-core/pkgs/container/relay-core%2Frelay-core).
+[relay-core package page](https://github.com/immersa-co/relay-core/pkgs/container/relay-core%2Frelay-core).
 
 ### Building a local Docker image
 
@@ -50,7 +50,7 @@ appropriately:
 You can also set the target using the configuration file. The configuration file
 gives you access to quite a few more advanced features; for more details, see
 the comments in the
-[default configuration file](https://github.com/fullstorydev/relay-core/blob/master/relay.yaml).
+[default configuration file](https://github.com/immersa-co/relay-core/blob/master/relay.yaml).
 You can use this file as a starting point when configuring Relay. You can test
 your configuration file by piping it into the Docker container when you run it.
 The `--config -` argument tells Relay to read its configuration from stdin:
@@ -67,7 +67,7 @@ the Docker image, so that your desired configuration becomes the new default.
 
 The configuration file can reference environment variables. You may find this
 useful in more complex scenarios. The
-[default configuration file](https://github.com/fullstorydev/relay-core/blob/master/relay.yaml)
+[default configuration file](https://github.com/immersa-co/relay-core/blob/master/relay.yaml)
 references a number of environment variables; you can use these variables as an
 alternative way to configure Relay. The `TRAFFIC_RELAY_TARGET` variable
 discussed above is an example of using this kind of environment variable

--- a/relay/environment/environment_test.go
+++ b/relay/environment/environment_test.go
@@ -3,7 +3,7 @@ package environment_test
 import (
 	"testing"
 
-	"github.com/fullstorydev/relay-core/relay/environment"
+	"github.com/immersa-co/relay-core/relay/environment"
 )
 
 type TestProvider struct {

--- a/relay/main/main.go
+++ b/relay/main/main.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/environment"
-	plugin_loader "github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
+	"github.com/immersa-co/relay-core/relay"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/environment"
+	plugin_loader "github.com/immersa-co/relay-core/relay/traffic/plugin-loader"
 )
 
 var logger = log.New(os.Stdout, "[relay] ", 0)

--- a/relay/options.go
+++ b/relay/options.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 type Options struct {

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -32,9 +32,9 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/version"
 )
 
 var (

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	content_blocker_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	content_blocker_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/version"
 )
 
 func TestContentBlocking(t *testing.T) {

--- a/relay/plugins/traffic/content-enricher-plugin/content-enricher-plugin.go
+++ b/relay/plugins/traffic/content-enricher-plugin/content-enricher-plugin.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/version"
 )
 
 var (

--- a/relay/plugins/traffic/content-enricher-plugin/content-enricher-plugin_test.go
+++ b/relay/plugins/traffic/content-enricher-plugin/content-enricher-plugin_test.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	content_enricher_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/content-enricher-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	content_enricher_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/content-enricher-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/version"
 )
 
 func TestContentEnriching(t *testing.T) {

--- a/relay/plugins/traffic/cookies-plugin/cookies-plugin.go
+++ b/relay/plugins/traffic/cookies-plugin/cookies-plugin.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var (

--- a/relay/plugins/traffic/cookies-plugin/cookies-plugin_test.go
+++ b/relay/plugins/traffic/cookies-plugin/cookies-plugin_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/cookies-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	cookies_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/cookies-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 func TestRelayedCookies(t *testing.T) {

--- a/relay/plugins/traffic/headers-plugin/headers-plugin.go
+++ b/relay/plugins/traffic/headers-plugin/headers-plugin.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var (

--- a/relay/plugins/traffic/headers-plugin/headers-plugin_test.go
+++ b/relay/plugins/traffic/headers-plugin/headers-plugin_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/headers-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	headers_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/headers-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 func TestHeadersPlugin(t *testing.T) {

--- a/relay/plugins/traffic/paths-plugin/paths-plugin.go
+++ b/relay/plugins/traffic/paths-plugin/paths-plugin.go
@@ -12,8 +12,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var (

--- a/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
+++ b/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	paths_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/paths-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 func TestPathRewriting(t *testing.T) {

--- a/relay/plugins/traffic/test-interceptor-plugin/test-interceptor-plugin.go
+++ b/relay/plugins/traffic/test-interceptor-plugin/test-interceptor-plugin.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var (

--- a/relay/service.go
+++ b/relay/service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var MonitorPath = "/__relay__up__/"

--- a/relay/test/util.go
+++ b/relay/test/util.go
@@ -3,11 +3,11 @@ package test
 import (
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	plugin_loader "github.com/immersa-co/relay-core/relay/traffic/plugin-loader"
 )
 
 // WithCatcherAndRelay is a helper function that wraps the setup and teardown

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/relay/version"
 )
 
 const RelayVersionHeaderName = "X-Relay-Version"

--- a/relay/traffic/plugin-interfaces.go
+++ b/relay/traffic/plugin-interfaces.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/fullstorydev/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/config"
 )
 
 // PluginFactory is the interface that the relay uses to create plugin

--- a/relay/traffic/plugin-loader/loader.go
+++ b/relay/traffic/plugin-loader/loader.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/fullstorydev/relay-core/relay/config"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/config"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 var logger = log.New(os.Stdout, "[traffic-plugin-loader] ", 0)

--- a/relay/traffic/plugin-loader/registry.go
+++ b/relay/traffic/plugin-loader/registry.go
@@ -1,13 +1,13 @@
 package plugin_loader
 
 import (
-	content_blocker_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
-	content_enricher_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/content-enricher-plugin"
-	cookies_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/cookies-plugin"
-	headers_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/headers-plugin"
-	paths_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
-	test_interceptor_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	content_blocker_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	content_enricher_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/content-enricher-plugin"
+	cookies_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/cookies-plugin"
+	headers_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/headers-plugin"
+	paths_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/paths-plugin"
+	test_interceptor_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/test-interceptor-plugin"
+	"github.com/immersa-co/relay-core/relay/traffic"
 )
 
 // DefaultPlugins is a plugin registry containing all traffic plugins that

--- a/relay/traffic/traffic_test.go
+++ b/relay/traffic/traffic_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fullstorydev/relay-core/catcher"
-	"github.com/fullstorydev/relay-core/relay"
-	test_interceptor_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
-	"github.com/fullstorydev/relay-core/relay/test"
-	"github.com/fullstorydev/relay-core/relay/traffic"
-	"github.com/fullstorydev/relay-core/relay/version"
+	"github.com/immersa-co/relay-core/catcher"
+	"github.com/immersa-co/relay-core/relay"
+	test_interceptor_plugin "github.com/immersa-co/relay-core/relay/plugins/traffic/test-interceptor-plugin"
+	"github.com/immersa-co/relay-core/relay/test"
+	"github.com/immersa-co/relay-core/relay/traffic"
+	"github.com/immersa-co/relay-core/relay/version"
 	"golang.org/x/net/websocket"
 )
 


### PR DESCRIPTION
- Changed all occurrences of `fullstorydev` to `immersa-co` in the codebase and documentation.
- Updated the GitHub owner in the release configuration file and the module path in the Makefile.
- Adjusted import paths in various Go files to align with the new module name.